### PR TITLE
fix: update dashboard variables

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -5500,10 +5500,7 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       }
     ]
   },


### PR DESCRIPTION
Import is currently broken with Grafana v11

![image](https://github.com/user-attachments/assets/38923332-693d-4f82-a363-51f39150ee9f)
