### PR TITLE
fix: use the right datasource variable for Source of metrics

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -3284,8 +3284,7 @@
       {
         "current": {},
         "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$PROMETHEUS_DS"
         },
         "definition": "label_values(base_thread_count,job)",
         "includeAll": false,


### PR DESCRIPTION
This PR updates the variables section to use the right source datasource for the `job` variable.

Without this update, dashboard provisioning import fails with 
![image](https://github.com/user-attachments/assets/01c9914d-876a-460e-b770-5bdb1e62d0f0)

Followup #3 


Note that I'm using this method for provisioning: https://grafana.com/docs/grafana/latest/administration/provisioning/#provision-folders-structure-from-filesystem-to-grafana with https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards