### PR TITLE
feat: use a stable dashboard UID

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -3329,8 +3329,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "KeyCloak MicroProfile Metrics",
-  "uid": null,
+  "title": "Keycloak",
+  "uid": "keycloak",
   "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
Using a stable dashboard UID allows to do persistent hrefs to dashboards.

This PR also updates the title to a more friendly "Keycloak"