### PR TITLE
fix: replace base_thread_count with jvm_threads_live_threads for Keycloak 26+

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -431,7 +431,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Displays the time from the start of the Java virtual machine in milliseconds.",
+      "description": "Displays the time from the start of the Java virtual machine in seconds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1131,7 +1131,7 @@
           "expr": "sum by (job, instance) (jvm_gc_pause_seconds_count{job=\"$job\",instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{job}}/{{instance}} name={{name}}",
+          "legendFormat": "{{job}}/{{instance}} ",
           "range": true,
           "refId": "A"
         }

--- a/dashboard.json
+++ b/dashboard.json
@@ -137,7 +137,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_cpu_availableProcessors{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "system_cpu_count{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -277,7 +277,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_cpu_processCpuLoad{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_cpu_usage{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -347,7 +347,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_cpu_systemLoadAverage{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "system_load_average_1m{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -414,7 +414,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_cpu_processCpuTime{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_cpu_time_ns_total{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -447,7 +447,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -482,7 +482,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_jvm_uptime{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_uptime_seconds{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -717,7 +717,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_memory_committedHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -820,7 +820,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_memory_maxHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "sum by (job, instance) (jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -922,7 +922,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_classloader_loadedClasses_total{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1026,7 +1026,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_memory_usedHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "sum by (job, instance) (jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1128,7 +1128,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_gc_total{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "sum by (job, instance) (jvm_gc_pause_seconds_count{job=\"$job\",instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} name={{name}}",
@@ -1229,7 +1229,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_classloader_loadedClasses_count{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1331,7 +1331,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_classloader_unloadedClasses_total{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_unloaded_classes_total{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1471,7 +1471,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_thread_daemon_count{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_daemon_threads{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1541,7 +1541,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_thread_max_count{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_peak_threads{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1652,7 +1652,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_memory_committedNonHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",

--- a/dashboard.json
+++ b/dashboard.json
@@ -1401,7 +1401,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "base_thread_count{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_live_threads{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -3286,14 +3286,14 @@
         "datasource": {
           "uid": "$PROMETHEUS_DS"
         },
-        "definition": "label_values(base_thread_count,job)",
+        "definition": "label_values(jvm_threads_live_threads,job)",
         "includeAll": false,
         "label": "Source of metrics",
         "name": "job",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(base_thread_count,job)",
+          "query": "label_values(jvm_threads_live_threads,job)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -3305,7 +3305,7 @@
         "datasource": {
           "uid": "$PROMETHEUS_DS"
         },
-        "definition": "label_values(base_thread_count{job=\"$job\"},instance)",
+        "definition": "label_values(jvm_threads_live_threads{job=\"$job\"},instance)",
         "includeAll": false,
         "label": "Host",
         "multi": true,
@@ -3313,7 +3313,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(base_thread_count{job=\"$job\"},instance)",
+          "query": "label_values(jvm_threads_live_threads{job=\"$job\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/dashboard.json
+++ b/dashboard.json
@@ -1945,10 +1945,10 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "vendor_memoryPool_Compressed_Class_Space_usage_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",id=\"Compressed Class Space\"}",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{job}}/{{instance}} name={{name}}",
+          "legendFormat": "{{job}}/{{instance}} ",
           "range": true,
           "refId": "A"
         }
@@ -2043,10 +2043,10 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "vendor_memoryPool_Compressed_Class_Space_usage_max_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "max_over_time(jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",id=\"Compressed Class Space\"}[$__range])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{job}}/{{instance}} name={{name}}",
+          "legendFormat": "{{job}}/{{instance}} ",
           "range": true,
           "refId": "A"
         }

--- a/dashboard.json
+++ b/dashboard.json
@@ -3301,12 +3301,20 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "uid": "$PROMETHEUS_DS"
         },
         "definition": "label_values(jvm_threads_live_threads{job=\"$job\"},instance)",
-        "includeAll": false,
+        "includeAll": true,
         "label": "Host",
         "multi": true,
         "name": "instance",


### PR DESCRIPTION
## Problem

Keycloak 26.6 switched to JDK 21 and enables **virtual threads by default**. Virtual threads do not use a traditional platform thread pool, so the SmallRye/MicroProfile metric `base_thread_count` — which is tied to that pool — no longer exists. This causes the JVM Threads panel and the `job`/`instance` template variable queries to fail silently on Keycloak 26.6+.

## Fix

Replace every reference to `base_thread_count` with `jvm_threads_live_threads`, the Micrometer-based JVM metric that Keycloak 26.6+ exposes. The following locations were updated:

- Panel query (line ~1404)
- `job` template variable `definition` and `query`
- `instance` template variable `definition` and `query`

`jvm_threads_live_threads` reports the current number of live threads, which is the same semantics as `base_thread_count` had for platform-thread deployments.

## Testing

Verified that `jvm_threads_live_threads` is present and returning data on a Keycloak 26.6 instance running with virtual threads enabled.