### PR TITLE
feat: Dual-query compatibility for Keycloak <26 and 26+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Visualize the corresponding KeyCloak metrics from the selected Grafana data sour
 - Version 4: Adjust the dashboard to shrink down the Grafana dashboard file
 - Version 5: Adjust the dashboard data source variable name
 - Version 6: Adjust the dashboard name
-- Version 7: Migrate to Micrometer metrics for Keycloak 26+ (virtual threads / JDK 21)
-- Version 8: Add dual-query compatibility for Keycloak <26 and 26+ via PromQL `or` fallbacks
+- Version 7: Adapt the metrics and the descriptions
+- Version 8: Migrate to Micrometer metrics for Keycloak 26+ (virtual threads / JDK 21) && and add dual-query compatibility for Keycloak <26 and 26+ via PromQL `or` fallbacks
 
 ## Images
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Description
 
-Includes a [KeyCloak](https://www.keycloak.org/) Grafana dashboard to display the Quarkus MicroProfile metrics.
+Includes a [KeyCloak](https://www.keycloak.org/) Grafana dashboard to display JVM and application metrics. Compatible with Keycloak 25 and earlier (MicroProfile/SmallRye `base_*` metrics) as well as Keycloak 26+ (Micrometer metrics).
 
 ## Functionality
 
-Visualize the corresponding KeyCloak Quarkus MicroProfile metrics from the selected Grafana data source.
+Visualize the corresponding KeyCloak metrics from the selected Grafana data source. The dashboard uses PromQL `or` fallbacks so it works transparently on both Keycloak <26 and Keycloak 26+ without any manual configuration.
 
 ## Grafana Dashboard
 
@@ -19,6 +19,8 @@ Visualize the corresponding KeyCloak Quarkus MicroProfile metrics from the selec
 - Version 4: Adjust the dashboard to shrink down the Grafana dashboard file
 - Version 5: Adjust the dashboard data source variable name
 - Version 6: Adjust the dashboard name
+- Version 7: Migrate to Micrometer metrics for Keycloak 26+ (virtual threads / JDK 21)
+- Version 8: Add dual-query compatibility for Keycloak <26 and 26+ via PromQL `or` fallbacks
 
 ## Images
 

--- a/dashboard.json
+++ b/dashboard.json
@@ -431,7 +431,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Displays the time from the start of the Java virtual machine. On Keycloak 26+, process_uptime_seconds is used (returns seconds, displayed as ms — values appear 1000x smaller). On Keycloak <26, base_jvm_uptime is used (returns ms correctly).",
+      "description": "Displays the time from the start of the Java virtual machine.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -447,9 +447,34 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -482,12 +507,24 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "process_uptime_seconds{job=\"$job\",instance=~\"$instance\"} or base_jvm_uptime{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_uptime_seconds{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$PROMETHEUS_DS"
+          },
+          "editorMode": "code",
+          "expr": "base_jvm_uptime{job=\"$job\",instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{job}}/{{instance}} ",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "JVM Uptime",

--- a/dashboard.json
+++ b/dashboard.json
@@ -3387,6 +3387,6 @@
   "timezone": "browser",
   "title": "KeyCloak Metrics",
   "uid": null,
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }

--- a/dashboard.json
+++ b/dashboard.json
@@ -137,7 +137,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "system_cpu_count{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "system_cpu_count{job=\"$job\",instance=~\"$instance\"} or base_cpu_availableProcessors{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -277,7 +277,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "process_cpu_usage{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_cpu_usage{job=\"$job\",instance=~\"$instance\"} or base_cpu_processCpuLoad{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -347,7 +347,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "system_load_average_1m{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "system_load_average_1m{job=\"$job\",instance=~\"$instance\"} or base_cpu_systemLoadAverage{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -414,7 +414,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "process_cpu_time_ns_total{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_cpu_time_ns_total{job=\"$job\",instance=~\"$instance\"} or base_cpu_processCpuTime{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -431,7 +431,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Displays the time from the start of the Java virtual machine in seconds.",
+      "description": "Displays the time from the start of the Java virtual machine. On Keycloak 26+, process_uptime_seconds is used (returns seconds, displayed as ms — values appear 1000x smaller). On Keycloak <26, base_jvm_uptime is used (returns ms correctly).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -447,7 +447,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -482,7 +482,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "process_uptime_seconds{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "process_uptime_seconds{job=\"$job\",instance=~\"$instance\"} or base_jvm_uptime{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -717,7 +717,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
+          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"}) or base_memory_committedHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -820,7 +820,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "sum by (job, instance) (jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
+          "expr": "sum by (job, instance) (jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"}) or base_memory_maxHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -922,7 +922,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"} or base_classloader_loadedClasses_total{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1026,7 +1026,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "sum by (job, instance) (jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"})",
+          "expr": "sum by (job, instance) (jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",area=\"heap\"}) or base_memory_usedHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1128,7 +1128,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "sum by (job, instance) (jvm_gc_pause_seconds_count{job=\"$job\",instance=~\"$instance\"})",
+          "expr": "sum by (job, instance) (jvm_gc_pause_seconds_count{job=\"$job\",instance=~\"$instance\"}) or base_gc_total{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1229,7 +1229,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_loaded_classes{job=\"$job\",instance=~\"$instance\"} or base_classloader_loadedClasses_count{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1331,7 +1331,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_classes_unloaded_classes_total{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_classes_unloaded_classes_total{job=\"$job\",instance=~\"$instance\"} or base_classloader_unloadedClasses_total{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1401,7 +1401,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_threads_live_threads{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_live_threads{job=\"$job\",instance=~\"$instance\"} or base_thread_count{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1471,7 +1471,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_threads_daemon_threads{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_daemon_threads{job=\"$job\",instance=~\"$instance\"} or base_thread_daemon_count{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1541,7 +1541,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_threads_peak_threads{job=\"$job\",instance=~\"$instance\"}",
+          "expr": "jvm_threads_peak_threads{job=\"$job\",instance=~\"$instance\"} or base_thread_max_count{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1652,7 +1652,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"nonheap\"})",
+          "expr": "sum by (job, instance) (jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",area=\"nonheap\"}) or base_memory_committedNonHeap_bytes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -1945,7 +1945,7 @@
             "uid": "$PROMETHEUS_DS"
           },
           "editorMode": "code",
-          "expr": "jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",id=\"Compressed Class Space\"}",
+          "expr": "jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",id=\"Compressed Class Space\"} or vendor_memoryPool_Compressed_Class_Space_usage_bytes{job=\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job}}/{{instance}} ",
@@ -2049,6 +2049,18 @@
           "legendFormat": "{{job}}/{{instance}} ",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$PROMETHEUS_DS"
+          },
+          "editorMode": "code",
+          "expr": "vendor_memoryPool_Compressed_Class_Space_usage_max_bytes{job=\"$job\",instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{job}}/{{instance}} ",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Peak usage of the Compressed Class Space memory pool",


### PR DESCRIPTION
## Problem

PR #12 migrated all `base_*` / `vendor_memoryPool_*` metrics to Micrometer equivalents for Keycloak 26+. This makes the dashboard work on 26+ but breaks it on older Keycloak versions where the Micrometer metrics do not exist.

## Fix

Add PromQL `or` fallbacks to every affected panel so the dashboard works on both versions simultaneously:

```
new_micrometer_metric{...} or legacy_base_metric{...}
```

Prometheus returns the left-hand side where it has data (Keycloak 26+), and the right-hand side fills in where it does not (Keycloak <26). Since both sides carry matching `job`/`instance` labels, no `ignoring()` clause is needed.

## Panels updated (18 total)

- CPU: count, process load, system load average, process CPU time
- JVM: uptime, heap committed/max/used, non-heap committed
- Classloader: loaded (total), loaded (count), unloaded
- GC: pause count
- Threads: live, daemon, peak
- Compressed Class Space: current usage (via `or`), peak usage (via second target entry — `max_over_time` cannot be combined with a plain gauge via `or`)

## JVM Uptime — per-refId unit overrides

`base_jvm_uptime` (Keycloak <26) returns milliseconds; `process_uptime_seconds` (Keycloak 26+) returns seconds. Rather than accepting a 1000x display error, the panel uses two separate targets and Grafana `byFrameRefID` field overrides to apply the correct unit per metric:

- Target A (`process_uptime_seconds`) → unit: `s`
- Target B (`base_jvm_uptime`) → unit: `ms`

Both versions display correctly with no manual configuration.

## Known limitation

Template variables (`job`, `instance`) use `label_values()`, which does not support `or`. They remain on `jvm_threads_live_threads` (26+ only). On Keycloak <26, the dropdowns will not auto-populate, but panel queries still work if the variables are pre-set.